### PR TITLE
Gobra IDE Release Handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,12 +88,18 @@ jobs:
         run: ln --symbolic ../../gobra
         working-directory: gobra-ide/server
 
+      - name: Set sbt cache variables
+        run: echo "SBT_OPTS='-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy'" >> $GITHUB_ENV
+        # note that the cache path is relative to directory in which sbt is invoked.
+        # hence, invoking sbt in server folder means that sbt cache will be in gobra-ide/server/sbt-cache
+
       - name: Cache SBT
         uses: actions/cache@v2
         with:
           path: |
-            ~/.ivy2/cache
-            ~/.sbt
+            gobra-ide/server/sbt-cache/.sbtboot
+            gobra-ide/server/sbt-cache/.boot
+            gobra-ide/server/sbt-cache/.ivy/cache
             gobra-ide/server/project/target
             gobra-ide/server/target
             gobra/project/target

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,10 +237,7 @@ jobs:
           name: server
           # place artifact at the same location as the build has produced it:
           path: gobra-ide/server/target/scala-2.12
-
-      - name: Echo Gobra Server Download Path
-        # note that download-path is the parent folder (not server.jar)
-        run: echo ${{steps.server-download.outputs.download-path}}
+          # note that download-path is the parent folder (not server.jar)
 
       - name: Install Node.js
         uses: actions/setup-node@v1.4.3
@@ -281,6 +278,8 @@ jobs:
         working-directory: gobra-ide/client
 
       - name: Upload Gobra server logs
+        # upload server logs in case of success AND failure:
+        if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v2
         with:
           name: gobraServer-${{ runner.os }}.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@
 
 name: test
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   build-and-test-server:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,6 +184,20 @@ jobs:
           java-version: '11'
       - run: java --version
 
+      - name: Cache npm
+        uses: actions/cache@v2
+        with:
+          path: gobra-ide/client/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Cache VSCode
+        uses: actions/cache@v2
+        with:
+          path: .vscode-test
+          key: ${{ runner.os }}-vscode
+
       - run: npm ci --cache .npm --prefer-offline
         working-directory: gobra-ide/client
 
@@ -202,11 +216,3 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'ubuntu') }}
         run: npm test
         working-directory: gobra-ide/client
-
-      - name: Cache npm
-        uses: actions/cache@v2
-        with:
-          path: gobra-ide/client/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,9 @@ jobs:
           path: deploy
 
   deploy-server:
-    needs: create-gobra-tools
+    # it would be sufficient to only need `create-gobra-tools`
+    # however, we only want to deploy if client test have completed successfully:
+    needs: [create-gobra-tools, build-and-test-client]
     runs-on: ubuntu-latest
     steps:
       - name: Download Gobra tools artifact
@@ -212,10 +214,14 @@ jobs:
 
       - name: Download Gobra server artifact
         uses: actions/download-artifact@v2
+        id: server-download
         with:
           name: server
           # place artifact at the same location as the build has produced it:
           path: gobra-ide/server/target/scala-2.12
+
+      - name: Gobra server was downloaded to:
+        run: echo ${{steps.server-download.outputs.download-path}}
 
       - name: Install Node.js
         uses: actions/setup-node@v1.4.3
@@ -245,18 +251,18 @@ jobs:
       - run: npm ci --cache .npm --prefer-offline
         working-directory: gobra-ide/client
 
-      - name: Start xvfb
+      - name: Start xvfb (ubuntu only)
         if: startsWith(matrix.os, 'ubuntu')
         run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & echo ">>> Started xvfb"
 
-      - name: Run tests on Ubuntu
+      - name: Run tests (ubuntu only)
         if: startsWith(matrix.os, 'ubuntu')
         env:
           DISPLAY: ':99.0'
         # run tests as sudo on ubutunu as this is required to install the extension to VSCode:
-        run: sudo npm test
+        run: sudo npm test -- gobra-server-jar-path=${{steps.server-download.outputs.download-path}}
         working-directory: gobra-ide/client
-      - name: Run tests not on Ubuntu
+      - name: Run tests (all except ubuntu)
         if: ${{ !startsWith(matrix.os, 'ubuntu') }}
-        run: npm test
+        run: npm test -- gobra-server-jar-path=${{steps.server-download.outputs.download-path}}
         working-directory: gobra-ide/client

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,21 @@
 
 name: test
 
-on: [push, workflow_dispatch]
+on:
+  push: # run this workflow on every push
+  pull_request: # run this workflow on every pull_request
+  workflow_dispatch: # allow to manually trigger this workflow
+  release:
+    types:
+      - created # run this workflow when creating a release
+  schedule:
+    - cron: '0 0 * * *' # run every day at 00:00
 
 jobs:
   build-and-test-server:
+    # build-and-test-server is the base job on which all other jobs depend
+    # we enforce here that the nightly build job only runs in the main repo:
+    if: (github.event_name == 'schedule' && github.repository == 'viperproject/gobra-ide') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     container: gobraverifier/gobra-base:v2
     steps:
@@ -99,8 +110,13 @@ jobs:
         run: sbt test
         working-directory: gobra-ide/server
 
-  deploy-server:
-    if: github.event_name == 'workflow_dispatch'
+  create-gobra-tools:
+    # run this command under the following circumstances:
+    # - created a new release
+    # - 'workflow_dispatch': manually triggered using the following POST request:
+    #   `curl -X POST -u <username>:<token> -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/viperproject/gobra-ide/actions/workflows/test.yml/dispatches" -d '{"ref":"<branch name>"}`
+    # - as part of our nightly build job (but only in the main repo)
+    if: (github.event_name == 'release' && github.event.action == 'created') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: build-and-test-server
     runs-on: ubuntu-latest
     steps:
@@ -133,12 +149,39 @@ jobs:
 
       - name: Create folder to later sync to AWS S3
         run: mkdir deploy
+        # note that we change into the tool folder to zip it. This avoids including the parent folder in the zip
       - name: Zip Gobra Tools for Windows
-        run: zip -r deploy/GobraToolsWin.zip GobraToolsWin
+        run: zip -r ../deploy/GobraToolsWin.zip ./*
+        working-directory: GobraToolsWin
       - name: Zip Gobra Tools for Linux
-        run: zip -r deploy/GobraToolsLinux.zip GobraToolsLinux
+        run: zip -r ../deploy/GobraToolsLinux.zip ./*
+        working-directory: GobraToolsLinux
       - name: Zip Gobra Tools for macOS
-        run: zip -r deploy/GobraToolsMac.zip GobraToolsMac
+        run: zip -r ../deploy/GobraToolsMac.zip ./*
+        working-directory: GobraToolsMac
+
+      - name: Upload Gobra tools artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: GobraTools
+          path: deploy
+
+  deploy-server:
+    needs: create-gobra-tools
+    runs-on: ubuntu-latest
+      - name: Download Gobra tools artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: GobraTools
+          path: deploy
+
+      - name: Set destination directory on AWS S3 (stable only)
+        if: github.event_name == 'release'
+        run: echo "DEST_DIR=stable" >> $GITHUB_ENV
+
+      - name: Set destination directory on AWS S3 (nightly only)
+        if: github.event_name != 'release'
+        run: echo "DEST_DIR=nightly" >> $GITHUB_ENV
 
       - name: Upload deploy folder to AWS S3
         uses: jakejarvis/s3-sync-action@v0.5.1
@@ -150,7 +193,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'eu-central-1'
           SOURCE_DIR: 'deploy'
-          DEST_DIR: 'nightly'
+          # DEST_DIR is set by the previous action to either 'stable' or 'nightly'
 
   build-and-test-client:
     needs: build-and-test-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,15 +113,15 @@ jobs:
           name: server
 
       - name: Download Viper Tools for Windows
-        run: curl --fail http://viper.ethz.ch/downloads/ViperToolsWin.zip --output ViperToolsWin.zip
+        run: curl --fail --silent --show-error http://viper.ethz.ch/downloads/ViperToolsWin.zip --output ViperToolsWin.zip
       - name: Unzip Viper Tools for Windows
         run: unzip ViperToolsWin.zip -d GobraToolsWin
       - name: Download Viper Tools for Linux
-        run: curl --fail http://viper.ethz.ch/downloads/ViperToolsLinux.zip --output ViperToolsLinux.zip
+        run: curl --fail --silent --show-error http://viper.ethz.ch/downloads/ViperToolsLinux.zip --output ViperToolsLinux.zip
       - name: Unzip Viper Tools for Linux
         run: unzip ViperToolsLinux.zip -d GobraToolsLinux
       - name: Download Viper Tools for macOS
-        run: curl --fail http://viper.ethz.ch/downloads/ViperToolsMac.zip --output ViperToolsMac.zip
+        run: curl --fail --silent --show-error http://viper.ethz.ch/downloads/ViperToolsMac.zip --output ViperToolsMac.zip
       - name: Unzip Viper Tools for macOS
         run: unzip ViperToolsMac.zip -d GobraToolsMac
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,18 @@ jobs:
           path: |
             ~/.ivy2/cache
             ~/.sbt
+            gobra-ide/server/project/target
+            gobra-ide/server/target
+            gobra/project/target
+            gobra/target
+            viperserver/project/target
+            viperserver/target
+            carbon/project/target
+            carbon/target
+            silicon/project/target
+            silicon/target
+            silver/project/target
+            silver/target
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
       - name: Assemble Gobra server
@@ -242,12 +254,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-
-      - name: Cache VSCode
-        uses: actions/cache@v2
-        with:
-          path: .vscode-test
-          key: ${{ runner.os }}-vscode
 
       - run: npm ci --cache .npm --prefer-offline
         working-directory: gobra-ide/client

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,8 @@ jobs:
           # place artifact at the same location as the build has produced it:
           path: gobra-ide/server/target/scala-2.12
 
-      - name: Gobra server was downloaded to
+      - name: Echo Gobra Server Download Path
+        # note that download-path is the parent folder (not server.jar)
         run: echo ${{steps.server-download.outputs.download-path}}
 
       - name: Install Node.js
@@ -260,9 +261,9 @@ jobs:
         env:
           DISPLAY: ':99.0'
         # run tests as sudo on ubutunu as this is required to install the extension to VSCode:
-        run: sudo npm test -- gobra-server-jar-path=${{steps.server-download.outputs.download-path}}
+        run: sudo npm test -- gobra-server-jar-path=${{steps.server-download.outputs.download-path}}/server.jar
         working-directory: gobra-ide/client
       - name: Run tests (all except ubuntu)
         if: ${{ !startsWith(matrix.os, 'ubuntu') }}
-        run: npm test -- gobra-server-jar-path=${{steps.server-download.outputs.download-path}}
+        run: npm test -- gobra-server-jar-path=${{steps.server-download.outputs.download-path}}/server.jar
         working-directory: gobra-ide/client

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
           # place artifact at the same location as the build has produced it:
           path: gobra-ide/server/target/scala-2.12
 
-      - name: Gobra server was downloaded to:
+      - name: Gobra server was downloaded to
         run: echo ${{steps.server-download.outputs.download-path}}
 
       - name: Install Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,8 +93,6 @@ jobs:
         # note that the cache path is relative to directory in which sbt is invoked.
         # hence, invoking sbt in server folder means that sbt cache will be in gobra-ide/server/sbt-cache
 
-      - run: echo $SBT_OPTS
-
       - name: Cache SBT
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,3 +279,9 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'ubuntu') }}
         run: npm test -- gobra-server-jar-path=${{steps.server-download.outputs.download-path}}/server.jar
         working-directory: gobra-ide/client
+
+      - name: Upload Gobra server logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: gobraServer-${{ runner.os }}.log
+          path: gobra-ide/client/gobraServer.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,14 +131,16 @@ jobs:
           mkdir -p GobraToolsLinux/server && cp server.jar GobraToolsLinux/server/server.jar
           mkdir -p GobraToolsMac/server && cp server.jar GobraToolsMac/server/server.jar
 
+      - name: Create folder to later sync to AWS S3
+        run: mkdir deploy
       - name: Zip Gobra Tools for Windows
-        run: zip -r GobraToolsWin.zip GobraToolsWin
+        run: zip -r deploy/GobraToolsWin.zip GobraToolsWin
       - name: Zip Gobra Tools for Linux
-        run: zip -r GobraToolsLinux.zip GobraToolsLinux
+        run: zip -r deploy/GobraToolsLinux.zip GobraToolsLinux
       - name: Zip Gobra Tools for macOS
-        run: zip -r GobraToolsMac.zip GobraToolsMac
+        run: zip -r deploy/GobraToolsMac.zip GobraToolsMac
 
-      - name: Upload Gobra Tools for Windows to AWS S3
+      - name: Upload deploy folder to AWS S3
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks
@@ -147,27 +149,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'eu-central-1'
-          SOURCE_DIR: 'GobraToolsWin.zip'
-      - name: Upload Gobra Tools for Linux to AWS S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --acl public-read --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'eu-central-1'
-          SOURCE_DIR: 'GobraToolsLinux.zip'
-      - name: Upload Gobra Tools for macOS to AWS S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --acl public-read --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'eu-central-1'
-          SOURCE_DIR: 'GobraToolsMac.zip'
+          SOURCE_DIR: 'deploy'
+          DEST_DIR: 'nightly'
 
   build-and-test-client:
     needs: build-and-test-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,9 +89,11 @@ jobs:
         working-directory: gobra-ide/server
 
       - name: Set sbt cache variables
-        run: echo "SBT_OPTS='-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy'" >> $GITHUB_ENV
+        run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV
         # note that the cache path is relative to directory in which sbt is invoked.
         # hence, invoking sbt in server folder means that sbt cache will be in gobra-ide/server/sbt-cache
+
+      - run: echo $SBT_OPTS
 
       - name: Cache SBT
         uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks
-          env:
+        env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -152,7 +152,7 @@ jobs:
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks
-          env:
+        env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -162,7 +162,7 @@ jobs:
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks
-          env:
+        env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,76 @@ jobs:
         run: sbt test
         working-directory: gobra-ide/server
 
+  deploy-server:
+    if: github.event_name == 'workflow_dispatch'
+    needs: build-and-test-server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install prerequisites
+        run: sudo apt-get install zip unzip
+
+      - name: Download Gobra server artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: server
+
+      - name: Download Viper Tools for Windows
+        run: curl --fail http://viper.ethz.ch/downloads/ViperToolsWin.zip --output ViperToolsWin.zip
+      - name: Unzip Viper Tools for Windows
+        run: unzip ViperToolsWin.zip -d GobraToolsWin
+      - name: Download Viper Tools for Linux
+        run: curl --fail http://viper.ethz.ch/downloads/ViperToolsLinux.zip --output ViperToolsLinux.zip
+      - name: Unzip Viper Tools for Linux
+        run: unzip ViperToolsLinux.zip -d GobraToolsLinux
+      - name: Download Viper Tools for macOS
+        run: curl --fail http://viper.ethz.ch/downloads/ViperToolsMac.zip --output ViperToolsMac.zip
+      - name: Unzip Viper Tools for macOS
+        run: unzip ViperToolsMac.zip -d GobraToolsMac
+
+      - name: Copy Gobra server artifact into each tool folder
+        run: |
+          mkdir -p GobraToolsWin/server && cp server.jar GobraToolsWin/server/server.jar
+          mkdir -p GobraToolsLinux/server && cp server.jar GobraToolsLinux/server/server.jar
+          mkdir -p GobraToolsMac/server && cp server.jar GobraToolsMac/server/server.jar
+
+      - name: Zip Gobra Tools for Windows
+        run: zip -r GobraToolsWin.zip GobraToolsWin
+      - name: Zip Gobra Tools for Linux
+        run: zip -r GobraToolsLinux.zip GobraToolsLinux
+      - name: Zip Gobra Tools for macOS
+        run: zip -r GobraToolsMac.zip GobraToolsMac
+
+      - name: Upload Gobra Tools for Windows to AWS S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --follow-symlinks
+          env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'eu-central-1'
+          SOURCE_DIR: 'GobraToolsWin.zip'
+      - name: Upload Gobra Tools for Linux to AWS S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --follow-symlinks
+          env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'eu-central-1'
+          SOURCE_DIR: 'GobraToolsLinux.zip'
+      - name: Upload Gobra Tools for macOS to AWS S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --follow-symlinks
+          env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'eu-central-1'
+          SOURCE_DIR: 'GobraToolsMac.zip'
+
   build-and-test-client:
     needs: build-and-test-server
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,7 @@ jobs:
   deploy-server:
     needs: create-gobra-tools
     runs-on: ubuntu-latest
+    steps:
       - name: Download Gobra tools artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Set sbt cache variables
         run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV
-        # note that the cache path is relative to directory in which sbt is invoked.
+        # note that the cache path is relative to the directory in which sbt is invoked.
         # hence, invoking sbt in server folder means that sbt cache will be in gobra-ide/server/sbt-cache
 
       - name: Cache SBT
@@ -186,7 +186,7 @@ jobs:
 
   deploy-server:
     # it would be sufficient to only need `create-gobra-tools`
-    # however, we only want to deploy if client test have completed successfully:
+    # however, we only want to deploy if the client tests have completed successfully:
     needs: [create-gobra-tools, build-and-test-client]
     runs-on: ubuntu-latest
     steps:

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -88,6 +88,33 @@
         }
       }
     },
+    "@sindresorhus/is": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
+      "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
+    "@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "dev": true,
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -112,6 +139,21 @@
         "@types/node": "*"
       }
     },
+    "@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
+      "dev": true
+    },
+    "@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -128,6 +170,15 @@
       "version": "14.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
       "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/vscode": {
       "version": "1.49.0",
@@ -263,6 +314,27 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "cacheable-lookup": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz",
+      "integrity": "sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w==",
+      "dev": true
+    },
+    "cacheable-request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^2.0.0"
+      }
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -334,6 +406,15 @@
         }
       }
     },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -374,11 +455,33 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "dev": true
+        }
+      }
+    },
+    "defer-to-connect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+      "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -404,22 +507,51 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-      "dev": true,
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "object.assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+          "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "es-array-method-boxes-properly": {
@@ -447,7 +579,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -552,8 +683,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -591,6 +721,25 @@
         "is-glob": "^4.0.1"
       }
     },
+    "got": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
+      "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^3.1.1",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -606,7 +755,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -620,13 +768,18 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
     "http-proxy-agent": {
@@ -651,6 +804,16 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "http2-wrapper": {
+      "version": "1.0.0-beta.5.2",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
+      "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+      "dev": true,
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
       }
     },
     "https-proxy-agent": {
@@ -710,14 +873,12 @@
     "is-callable": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
-      "dev": true
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
     },
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -762,7 +923,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
       "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -783,7 +943,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -832,6 +991,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
@@ -839,6 +1004,15 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^1.0.0"
+      }
+    },
+    "keyv": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.1"
       }
     },
     "locate-java-home": {
@@ -871,6 +1045,18 @@
       "requires": {
         "chalk": "^4.0.0"
       }
+    },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -950,17 +1136,21 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -981,6 +1171,12 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "p-cancelable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+      "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+      "dev": true
     },
     "p-limit": {
       "version": "3.0.2",
@@ -1062,6 +1258,12 @@
         "once": "^1.3.1"
       }
     },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1099,6 +1301,21 @@
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-alpn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
+      "integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==",
+      "dev": true
+    },
+    "responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^2.0.0"
       }
     },
     "rimraf": {
@@ -1155,7 +1372,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -1165,7 +1381,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -1310,7 +1525,7 @@
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
     "vs-verification-toolbox": {
-      "version": "git://github.com/viperproject/vs-verification-toolbox.git#38b111224292784fa151e65fef48e8f0395aaf09",
+      "version": "git://github.com/viperproject/vs-verification-toolbox.git#3aa85f35c29209d08e2806d1285fb3fe69ecaa47",
       "from": "git://github.com/viperproject/vs-verification-toolbox.git",
       "dev": true,
       "requires": {
@@ -1318,6 +1533,7 @@
         "@types/vscode": "^1.43.0",
         "extract-zip": "^2.0.0",
         "fs-extra": "^9.0.0",
+        "got": "^11.7.0",
         "vscode-test": "^1.3.0"
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -313,14 +313,14 @@
           "type": "object",
           "default": {
             "stable": {
-              "windows": "http://viper.ethz.ch/downloads/ViperToolsWin.zip",
-              "linux": "http://viper.ethz.ch/downloads/ViperToolsLinux.zip",
-              "mac": "http://viper.ethz.ch/downloads/ViperToolsMac.zip"
+              "windows": "https://gobra-ide.s3.eu-central-1.amazonaws.com/stable/GobraToolsWin.zip",
+              "linux": "https://gobra-ide.s3.eu-central-1.amazonaws.com/stable/GobraToolsLinux.zip",
+              "mac": "https://gobra-ide.s3.eu-central-1.amazonaws.com/stable/GobraToolsMac.zip"
             },
             "nightly": {
-              "windows": "http://viper.ethz.ch/downloads/ViperToolsWin.zip",
-              "linux": "http://viper.ethz.ch/downloads/ViperToolsLinux.zip",
-              "mac": "http://viper.ethz.ch/downloads/ViperToolsMac.zip"
+              "windows": "https://gobra-ide.s3.eu-central-1.amazonaws.com/nightly/GobraToolsWin.zip",
+              "linux": "https://gobra-ide.s3.eu-central-1.amazonaws.com/nightly/GobraToolsLinux.zip",
+              "mac": "https://gobra-ide.s3.eu-central-1.amazonaws.com/nightly/GobraToolsMac.zip"
             }
           }
         }

--- a/client/src/ExtensionState.ts
+++ b/client/src/ExtensionState.ts
@@ -142,7 +142,7 @@ export class State {
       });
 
       // start Gobra Server given in binary
-      console.log("Starting Gobra Server");
+      console.log(`Starting Gobra Server with binary ${serverBin}`);
       server.listen(() => {
         let serverAddress = server.address() as net.AddressInfo;
         let processArgs = ['-Xss128m', '-jar', serverBin, serverAddress.port.toString()];

--- a/client/src/ExtensionState.ts
+++ b/client/src/ExtensionState.ts
@@ -85,13 +85,10 @@ export class State {
 
 
 
-    // TODO: change this once the zip downloads are ready.
-    //let serverBin = Helper.getServerJarPath(Helper.isNightly());
-    //let serverBin = context.asAbsolutePath(path.join('../', 'server', 'target', 'scala-2.12', 'server.jar'));
-
-    // NOTE: this is only hardcoded for the moment to be able to test the extension, evaluate it. later this will be replaced by the stable, nightly bin as above.
-    let prefix = __dirname.split("client")[0];
-    let serverBin = path.join(prefix, 'server', 'target', 'scala-2.12', 'server.jar')
+    const serverBin = Helper.getServerJarPath(Helper.isNightly());
+    // use the following serverBin when you want to directly use the compiled server jar:
+    // const prefix = __dirname.split("client")[0];
+    // const serverBin = path.join(prefix, 'server', 'target', 'scala-2.12', 'server.jar')
 
     let serverOptions: ServerOptions = () => State.startServerProcess(serverBin);
 

--- a/client/src/Helper.ts
+++ b/client/src/Helper.ts
@@ -146,8 +146,6 @@ export class Helper {
       "java" + (Helper.isWin ? ".exe" : "")
     );
   }
-
-  // TODO: change paths of providers to actual zips when they exist and also use server from this zip
   
   /**
     * Get URL of repository where Gobra Tools are hosted.

--- a/client/src/test/extension.test.ts
+++ b/client/src/test/extension.test.ts
@@ -91,9 +91,11 @@ suite("Extension", () => {
         this.timeout(GOBRA_TOOL_UPDATE_TIMEOUT_MS);
         // check whether a path to the gobra tools has been manually provided and if yes, set it as extension settings:
         let setServerJarPathPromise;
-        if (process.env["gobra_server_jar_path"]) {
+        const gobraServerJarPath = process.env["gobra_server_jar_path"];
+        if (gobraServerJarPath) {
             previousServerJarPath = getServerJarPath();
-            setServerJarPathPromise = setServerJarPath(process.env["gobra_server_jar_path"]);
+            setServerJarPathPromise = setServerJarPath(gobraServerJarPath)
+                .then(() => log(`successfully set gobra server binary settings to ${gobraServerJarPath}`));
         } else {
             setServerJarPathPromise = Promise.resolve();
         }
@@ -164,7 +166,8 @@ suite("Extension", () => {
         // restore gobra tools path in case we have changed the settings for running these tests:
         let restoreServerJarPathPromise;
         if (previousServerJarPath) {
-            restoreServerJarPathPromise = setServerJarPath(previousServerJarPath);
+            restoreServerJarPathPromise = setServerJarPath(previousServerJarPath)
+                .then(() => log(`successfully restored gobra server binary settings to ${previousServerJarPath}`));
         } else {
             restoreServerJarPathPromise = Promise.resolve();
         }

--- a/client/src/test/extension.test.ts
+++ b/client/src/test/extension.test.ts
@@ -8,8 +8,9 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { State } from '../ExtensionState';
-import { Commands } from '../Helper';
+import { Commands, Helper } from '../Helper';
 import { TestHelper } from './TestHelper';
+import { PathSettings } from '../MessagePayloads';
 
 const PROJECT_ROOT = path.join(__dirname, "../../");
 const DATA_ROOT = path.join(PROJECT_ROOT, "src", "test", "data");
@@ -24,6 +25,40 @@ function log(msg: string) {
 
 function getTestDataPath(fileName: string): string {
     return path.join(DATA_ROOT, fileName);
+}
+
+const gobraToolsPathsSection = "gobraDependencies.gobraToolsPaths";
+function getServerJarPath(): string {
+    const config = vscode.workspace.getConfiguration();
+    const toolsPathsConfig = config.get(gobraToolsPathsSection) as PathSettings;
+    if (Helper.isWin) {
+        return toolsPathsConfig.serverJar.windows;
+    } else if (Helper.isLinux) {
+        return toolsPathsConfig.serverJar.linux;
+    } else if (Helper.isMac) {
+        return toolsPathsConfig.serverJar.mac;
+    } else {
+        return null;
+    }
+}
+
+function setServerJarPath(path: string): Thenable<void> {
+    const config = vscode.workspace.getConfiguration();
+    const toolsPathsConfig = config.get(gobraToolsPathsSection) as PathSettings;
+    if (Helper.isWin) {
+        toolsPathsConfig.serverJar.windows = path;
+    } else if (Helper.isLinux) {
+        toolsPathsConfig.serverJar.linux = path;
+    } else if (Helper.isMac) {
+        toolsPathsConfig.serverJar.mac = path;
+    } else {
+        return Promise.reject("unkown platform");
+    }
+    
+    return config.update(
+        gobraToolsPathsSection,
+        toolsPathsConfig,
+        vscode.ConfigurationTarget.Global);
 }
 
 /**
@@ -49,11 +84,22 @@ async function openAndVerify(fileName: string): Promise<vscode.TextDocument> {
 
 suite("Extension", () => {
 
+    let previousServerJarPath: string;
+
     suiteSetup(function() {
         // set timeout to a large value such that extension can be started and Gobra tools installed:
         this.timeout(GOBRA_TOOL_UPDATE_TIMEOUT_MS);
+        // check whether a path to the gobra tools has been manually provided and if yes, set it as extension settings:
+        let setServerJarPathPromise;
+        if (process.env["gobra_server_jar_path"]) {
+            previousServerJarPath = getServerJarPath();
+            setServerJarPathPromise = setServerJarPath(process.env["gobra_server_jar_path"]);
+        } else {
+            setServerJarPathPromise = Promise.resolve();
+        }
         // activate extension:
-        return TestHelper.startExtension(getTestDataPath(ASSERT_TRUE))
+        return setServerJarPathPromise
+            .then(() => TestHelper.startExtension(getTestDataPath(ASSERT_TRUE)))
             .then(() => log("suiteSetup done"));
     });
     
@@ -115,7 +161,15 @@ suite("Extension", () => {
     });
 
     suiteTeardown(function() {
-        return TestHelper.stopExtension()
+        // restore gobra tools path in case we have changed the settings for running these tests:
+        let restoreServerJarPathPromise;
+        if (previousServerJarPath) {
+            restoreServerJarPathPromise = setServerJarPath(previousServerJarPath);
+        } else {
+            restoreServerJarPathPromise = Promise.resolve();
+        }
+        return restoreServerJarPathPromise
+            .then(() => TestHelper.stopExtension())
             .then(() => log(`the extension was stopped successfully`));
     });
 });

--- a/client/src/test/runTest.ts
+++ b/client/src/test/runTest.ts
@@ -32,16 +32,34 @@ function main(): Promise<number> {
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, 'index.js');
 
+		// check whether a command line argument was passed as `-- gobra-server-jar-path=<path to jar>`:
+		const gobraServerJarPathPrefix = "gobra-server-jar-path=";
+		const gobraServerJarPathArg = process.argv
+			.find(s => s.startsWith(gobraServerJarPathPrefix));
+		let extensionTestsEnv;
+		if (gobraServerJarPathArg) {
+			extensionTestsEnv = {
+				"gobra_server_jar_path": gobraServerJarPathArg.replace(gobraServerJarPathPrefix, "")
+			};
+		} else {
+			extensionTestsEnv = undefined;
+		}
+
 		const testOption = { 
 			extensionDevelopmentPath: extensionDevelopmentPath, 
-			extensionTestsPath: extensionTestsPath 
+			extensionTestsPath: extensionTestsPath,
+			extensionTestsEnv: extensionTestsEnv,
 		};
 		// Download VS Code, unzip it and run the integration test
-		return runTests(testOption);
+		return runTests(testOption)
+			.catch((err) => {
+				console.error(`runTests has failed with error: ${err}`);
+				return Promise.resolve(1);
+			});
 	} catch (err) {
         console.error(err);
 		console.error('Failed to run tests');
-		return Promise.resolve(-1);
+		return Promise.resolve(1);
 	}
 }
 
@@ -49,4 +67,8 @@ main()
 	.then((exitCode: number) => {
 		console.log(`main function has ended, exitCode: ${exitCode}`);
 		process.exit(exitCode);
+	})
+	.catch((err) => {
+		console.log(`main function has ended with an error: ${err}`);
+		process.exit(1);
 	});


### PR DESCRIPTION
Adapts CI as follows:
- nightly builds triggered at 00:00 (this will happen only when this PR will be merged into master)
- stable builds triggered when creating a new releases on GitHub
- improved caching for sbt
- creation of Gobra tools (downloads Viper tools and adds server jar to them) (only done for nightly and stable builds)
- uploads Gobra tools to AWS S3
- adapts client's default settings to use AWS S3
- adapts client tests to accept a path to the server jar as a command line argument. The CI uses this argument to provide the currently compiled server.jar to the tests (instead of using the latest stable release)

I suggest to perform a squash commit as this PR consists of many commits needed to test the CI
