### PR TITLE
Improved Exception Handling

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -36,14 +36,10 @@ Right clicking on some selected code in a Gobra program reveals two actions, "Sh
 Both actions result in a preview, on the right-hand side, of the internal representation used by Gobra and the resulting code in the Viper intermediate language, respectively.
 The translated parts of the selected code are marked in green.
 
+## Limitations
+Gobra IDE currently only supports verification of single files.
+Other files located in the same folder are ignored.
+Furthermore, it is at the moment not possible to configure Gobra IDE to consider other directories than specified in the `GOPATH` environment variable when importing packages.
+
 ## Requirements
 - [Java Runtime Environment (or JDK), 64 bit, version 1.8 or later](https://www.java.com/en/download/)
-
-## Gobra Tools Provider
-The provider of the Gobra Tools can be configured in the Gobra settings.
-In addition to regular URLs, the following URLs have a special meaning:
-- `github.com/<owner>/<repo>/releases/latest?asset-name=<asset name>`: Downloads a GitHub release artifact with the given name from the latest non-pre-release of the specified repository
-- `github.com/<owner>/<repo>/releases/latest?asset-name=<asset name>&include-prereleases`: Downloads a GitHub release artifact with the given name from the latest pre- or non-pre-release of the specified repository
-- `github.com/<owner>/<repo>/releases/tags/<tag>?asset-name=<asset name>`: Downloads a GitHub release artifact with the given name from the release identified by the git tag of the specified repository
-
-Note that regular URLs as well as GitHub release assets have to point to a ZIP file.

--- a/client/package.json
+++ b/client/package.json
@@ -201,7 +201,7 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "Gobra Configuration",
+      "title": "Gobra",
       "properties": {
         "gobraSettings.serverMode": {
           "scope": "window",

--- a/server/src/main/scala/viper/gobraserver/GobraServer.scala
+++ b/server/src/main/scala/viper/gobraserver/GobraServer.scala
@@ -65,7 +65,7 @@ object GobraServer extends GobraFrontend {
 
     val fileUri = fileData.fileUri
 
-    // do some post precessing if verification has failed
+    // do some post processing if verification has failed
     resultFuture.recoverWith({ case exception =>
       // restart Gobra Server and then update client state
       restart()

--- a/server/src/main/scala/viper/gobraserver/GobraServer.scala
+++ b/server/src/main/scala/viper/gobraserver/GobraServer.scala
@@ -42,22 +42,23 @@ object GobraServer extends GobraFrontend {
   private var _options: List[String] = List()
   private var _server: ViperCoreServer = _
 
-  def init(options: List[String]) {
+  def init(options: List[String]): Unit = {
     _options = options
     _server = new ViperCoreServer(options.toArray)
     ViperBackends.ViperServerBackend.setServer(_server)
   }
 
-  def start() {
+  def start(): Unit = {
     _verifier = new Gobra
     _server.start()
     VerifierState.flushCachedDiagnostics()
   }
 
-  def restart() {
-    _server.stop()
-    ViperBackends.ViperServerBackend.resetServer()
-    init(_options)
+  def restart(): Unit = {
+    stop()
+    delete()
+    val options = _options
+    init(options)
     start()
   }
 
@@ -220,7 +221,7 @@ object GobraServer extends GobraFrontend {
   /**
     * Gobrafy File.
     */
-  def gobrafy(fileData: FileData) {
+  def gobrafy(fileData: FileData): Unit = {
     var success = false
 
     val filePath = fileData.filePath
@@ -260,23 +261,23 @@ object GobraServer extends GobraFrontend {
     * Get preview of Code which then gets displayed on the client side.
     * Currently the internal representation and the viper encoding can be previewed.
     */
-  def codePreview(fileData: FileData, internalPreview: Boolean, viperPreview: Boolean, selections: List[Range]) {
+  def codePreview(fileData: FileData, internalPreview: Boolean, viperPreview: Boolean, selections: List[Range]): Future[VerifierResult] = {
     val config = Helper.previewConfigFromTask(fileData, internalPreview, viperPreview, selections)
-    val previewFuture = verifier.verify(config)
+    verifier.verify(config)
   }
 
 
-  def stop() {
+  def stop(): Unit = {
     _server.stop()
   }
 
-  def flushCache() {
+  def flushCache(): Unit = {
     _server.flushCache()
     VerifierState.flushCachedDiagnostics()
     VerifierState.changes = List()
   }
 
-  def delete() {
+  def delete(): Unit = {
     ViperBackends.ViperServerBackend.resetServer()
     _server = null
   } 


### PR DESCRIPTION
Building up on [Gobra PR #110](https://github.com/viperproject/gobra/pull/110), this PR improves the already existing exception handling in Gobra Server. Previously `start` was called to restart the Gobra Server. However now that ViperServer and Gobra are using Akka Actors, one has to be careful to first shutdown the actor system before creating a new one with the same name (as actor names have to be unique).

The main contributions of this PR are as follows:
1. adds a `restart` function that takes above consideration into account and restarts ViperCoreServer and Gobra
2. `serverExceptionHandling` first restarts ViperCoreServer and Gobra before informing clients (instead of the other way around)
3. `serverExceptionHandling` returns a future that resolves after verification is done and exception handling has been applied (if necessary). This should mainly be useful for the future. Currently, only the `VerificationWorker` uses it and hence waits a little longer than before (previously the VerificationWorker would have waited until a verification result or an exception has occurred and now it waits until the error handling is performed as well)