### PR TITLE
Escape Path to Gobra Tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,7 +276,7 @@ jobs:
         if: "!startsWith(matrix.os, 'windows')"
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: npm test --full-trace -- --server ${{steps.server-download.outputs.download-path}}/server.jar --ignoreServerBackwardCompatibility
+          run: npm test --full-trace -- --server "${{steps.server-download.outputs.download-path}}/server.jar" --ignoreServerBackwardCompatibility
           working-directory: gobra-ide/client
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -285,7 +285,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: npm test --full-trace -- --server ${{steps.server-download.outputs.download-path}}\server.jar --ignoreServerBackwardCompatibility
+          run: npm test --full-trace -- --server "${{steps.server-download.outputs.download-path}}\server.jar" --ignoreServerBackwardCompatibility
           working-directory: gobra-ide/client
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,7 +273,7 @@ jobs:
         working-directory: gobra-ide/client
 
       - name: Run tests (headless - non-windows)
-        if: {{ !(startsWith(matrix.os, 'windows') }}
+        if: {{ !startsWith(matrix.os, 'windows') }}
         uses: GabrielBB/xvfb-action@v1
         id: runTests
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -272,11 +272,22 @@ jobs:
       - run: npm ci --cache .npm --prefer-offline
         working-directory: gobra-ide/client
 
-      - name: Run tests (headless)
+      - name: Run tests (headless - non-windows)
+        if: {{ !(startsWith(matrix.os, 'windows') }}
         uses: GabrielBB/xvfb-action@v1
         id: runTests
         with:
           run: npm test --full-trace -- --server ${{steps.server-download.outputs.download-path}}/server.jar --ignoreServerBackwardCompatibility
+          working-directory: gobra-ide/client
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests (headless - windows only)
+        if: startsWith(matrix.os, 'windows')
+        uses: GabrielBB/xvfb-action@v1
+        id: runTests
+        with:
+          run: npm test --full-trace -- --server ${{steps.server-download.outputs.download-path}}\server.jar --ignoreServerBackwardCompatibility
           working-directory: gobra-ide/client
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,7 +273,7 @@ jobs:
         working-directory: gobra-ide/client
 
       - name: Run tests (headless - non-windows)
-        if: {{ !startsWith(matrix.os, 'windows') }}
+        if: "!startsWith(matrix.os, 'windows')"
         uses: GabrielBB/xvfb-action@v1
         id: runTests
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,7 +275,6 @@ jobs:
       - name: Run tests (headless - non-windows)
         if: "!startsWith(matrix.os, 'windows')"
         uses: GabrielBB/xvfb-action@v1
-        id: runTests
         with:
           run: npm test --full-trace -- --server ${{steps.server-download.outputs.download-path}}/server.jar --ignoreServerBackwardCompatibility
           working-directory: gobra-ide/client
@@ -285,7 +284,6 @@ jobs:
       - name: Run tests (headless - windows only)
         if: startsWith(matrix.os, 'windows')
         uses: GabrielBB/xvfb-action@v1
-        id: runTests
         with:
           run: npm test --full-trace -- --server ${{steps.server-download.outputs.download-path}}\server.jar --ignoreServerBackwardCompatibility
           working-directory: gobra-ide/client
@@ -293,13 +291,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Collect coverage
-        if: ${{ steps.runTests.outcome == 'success' }}
         run: npx nyc report --reporter=lcov
         working-directory: gobra-ide/client
 
 #      - name: Upload coverage to Codecov
 #        uses: codecov/codecov-action@v1
-#        if: ${{ steps.runTests.outcome == 'success' }}
 #        with:
 #          token: ${{ secrets.CODECOV_TOKEN }}
 #          file: gobra-ide/client/coverage/lcov.info

--- a/client/src/ExtensionState.ts
+++ b/client/src/ExtensionState.ts
@@ -155,7 +155,7 @@ export class State {
       const processArgs = Helper.getServerProcessArgs(serverBin);
       const command = `${javaPath} ${processArgs}`;
       Helper.log(`Gobra IDE: Running '${command}'`);
-      // enable shell mode such that arguments to not need to be passed as an array
+      // enable shell mode such that arguments do not need to be passed as an array
       // see https://stackoverflow.com/a/45134890/1990080
       const serverProcess = child_process.spawn(command, [], { shell: true });
       // redirect stdout to readline which nicely combines and splits lines

--- a/client/src/ExtensionState.ts
+++ b/client/src/ExtensionState.ts
@@ -153,8 +153,11 @@ export class State {
       }
 
       const processArgs = Helper.getServerProcessArgs(serverBin);
-      Helper.log(`Gobra IDE: Running '${javaPath} ${processArgs.join(' ')}'`);
-      const serverProcess = child_process.spawn(javaPath, processArgs);
+      const command = `${javaPath} ${processArgs}`;
+      Helper.log(`Gobra IDE: Running '${command}'`);
+      // enable shell mode such that arguments to not need to be passed as an array
+      // see https://stackoverflow.com/a/45134890/1990080
+      const serverProcess = child_process.spawn(command, [], { shell: true });
       // redirect stdout to readline which nicely combines and splits lines
       const rl = readline.createInterface({ input: serverProcess.stdout });
       rl.on('line', stdOutLineHandler);

--- a/client/src/Helper.ts
+++ b/client/src/Helper.ts
@@ -180,7 +180,7 @@ export class Helper {
       Helper.log(`Error: server jar file should be located at '${serverBinary}' but it does not exist`);
     }
     const configuredArgString = Helper.getGobraDependencies().java.javaArguments
-      .replace("$serverBinary$", `'${serverBinary}'`); // escape `serverBinary` in case it contains spaces
+      .replace("$serverBinary$", `"${serverBinary}"`); // escape `serverBinary` in case it contains spaces
     return configuredArgString;
   }
   

--- a/client/src/Helper.ts
+++ b/client/src/Helper.ts
@@ -175,10 +175,10 @@ export class Helper {
     }
   }
 
-  public static getServerProcessArgs(serverBinary: string): string[] {
+  public static getServerProcessArgs(serverBinary: string): string {
     const configuredArgString = Helper.getGobraDependencies().java.javaArguments
-      .replace("$serverBinary$", serverBinary);
-    return configuredArgString.split(" ");
+      .replace("$serverBinary$", `'${serverBinary}'`); // escape server binary in case it contains spaces
+    return configuredArgString;
   }
   
   /**

--- a/client/src/Helper.ts
+++ b/client/src/Helper.ts
@@ -6,7 +6,6 @@
 
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
-import * as fs from "fs";
 import { VerifierConfig, OverallVerificationResult, FileData, GobraSettings, PlatformDependendPath, GobraDependencies, PreviewData, HighlightingPosition } from "./MessagePayloads";
 import * as locate_java_home from 'locate-java-home';
 import * as child_process from 'child_process';
@@ -176,9 +175,6 @@ export class Helper {
   }
 
   public static getServerProcessArgs(serverBinary: string): string {
-    if (!fs.existsSync(serverBinary)) {
-      Helper.log(`Error: server jar file should be located at '${serverBinary}' but it does not exist`);
-    }
     const configuredArgString = Helper.getGobraDependencies().java.javaArguments
       .replace("$serverBinary$", `"${serverBinary}"`); // escape `serverBinary` in case it contains spaces
     return configuredArgString;

--- a/client/src/Helper.ts
+++ b/client/src/Helper.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
-import * as path from "path";
+import * as fs from "fs";
 import { VerifierConfig, OverallVerificationResult, FileData, GobraSettings, PlatformDependendPath, GobraDependencies, PreviewData, HighlightingPosition } from "./MessagePayloads";
 import * as locate_java_home from 'locate-java-home';
 import * as child_process from 'child_process';
@@ -176,6 +176,9 @@ export class Helper {
   }
 
   public static getServerProcessArgs(serverBinary: string): string {
+    if (!fs.existsSync(serverBinary)) {
+      Helper.log(`Error: server jar file should be located at '${serverBinary}' but it does not exist`);
+    }
     const configuredArgString = Helper.getGobraDependencies().java.javaArguments
       .replace("$serverBinary$", `'${serverBinary}'`); // escape `serverBinary` in case it contains spaces
     return configuredArgString;

--- a/client/src/Helper.ts
+++ b/client/src/Helper.ts
@@ -177,7 +177,7 @@ export class Helper {
 
   public static getServerProcessArgs(serverBinary: string): string {
     const configuredArgString = Helper.getGobraDependencies().java.javaArguments
-      .replace("$serverBinary$", `'${serverBinary}'`); // escape server binary in case it contains spaces
+      .replace("$serverBinary$", `'${serverBinary}'`); // escape `serverBinary` in case it contains spaces
     return configuredArgString;
   }
   


### PR DESCRIPTION
Fixes issue that Gobra extension does not start when spaces are present in the path to the installed Gobra Tools. Note that this situation occurs e.g. on macOS when using VSCode's `globalStorageUri` or `globalStoragePath` as it resolves to: `/Users/<username>/Library/Application Support/Code/User/globalStorage/viper-admin.gobra-ide`