### PR TITLE
Runs Gobra Server Relative to a tmp Folder

### DIFF
--- a/client/src/ExtensionState.ts
+++ b/client/src/ExtensionState.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as net from 'net';
 import * as child_process from "child_process";
 import * as readline from 'readline';
+import * as os from 'os';
 import { FileData, VerifierConfig } from "./MessagePayloads";
 import { Helper, FileSchemes } from "./Helper";
 import { IdeEvents } from "./IdeEvents";
@@ -154,10 +155,11 @@ export class State {
 
       const processArgs = Helper.getServerProcessArgs(serverBin);
       const command = `"${javaPath}" ${processArgs}`; // processArgs is already escaped but escape javaPath as well.
-      Helper.log(`Gobra IDE: Running '${command}'`);
+      const tmpDir = os.tmpdir();
+      Helper.log(`Gobra IDE: Running '${command}' (relative to '${tmpDir}')`);
       // enable shell mode such that arguments do not need to be passed as an array
       // see https://stackoverflow.com/a/45134890/1990080
-      const serverProcess = child_process.spawn(command, [], { shell: true });
+      const serverProcess = child_process.spawn(command, [], { shell: true, cwd: tmpDir });
       // redirect stdout to readline which nicely combines and splits lines
       const rl = readline.createInterface({ input: serverProcess.stdout });
       rl.on('line', stdOutLineHandler);


### PR DESCRIPTION
Explicitly sets the current working directory of Gobra Server to be a temporary folder to enable Silicon creating its log files