### PR TITLE
Gobra Tools Paths only influences Build Version 'Local'

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -304,7 +304,7 @@
             "Local"
           ],
           "default": "Stable",
-          "description": "Select the build version of the Gobra Tools. The path specified at 'gobraDependencies.gobraToolsPaths.gobraToolsBasePath' will be used for build version 'Local'"
+          "description": "Select the build version of the Gobra Tools. The paths specified at 'gobraDependencies.gobraToolsPaths' will be used for build version 'Local' and ignored otherwise."
         },
         "gobraSettings.timeout": {
           "scope": "window",
@@ -358,9 +358,9 @@
           "type": "object",
           "default": {
             "gobraToolsBasePath": {
-              "windows": "%APPDATA%\\Gobra\\",
-              "linux": "$HOME/.config/Gobra",
-              "mac": "$HOME/Library/Application Support/Gobra"
+              "windows": "%APPDATA%\\Roaming\\Code\\User\\globalStorage\\viper-admin.gobra-ide\\Local\\GobraTools",
+              "linux": "$HOME/.config/Code/User/globalStorage/viper-admin.gobra-ide/Local/GobraTools",
+              "mac": "$HOME/Library/Application Support/Code/User/globalStorage/viper-admin.gobra-ide/Local/GobraTools"
             },
             "z3Executable": {
               "windows": "$gobraTools$\\z3\\bin\\z3.exe",
@@ -378,7 +378,7 @@
               "mac": "$gobraTools$/server/server.jar"
             }
           },
-          "description": "Paths to the dependencies."
+          "description": "Paths to the dependencies. Only considered for build version 'Local'."
         },
         "gobraDependencies.gobraToolsProvider": {
           "type": "object",

--- a/client/src/ExtensionState.ts
+++ b/client/src/ExtensionState.ts
@@ -170,11 +170,15 @@ export class State {
     vscode.workspace.registerTextDocumentContentProvider(FileSchemes.internal, this.internalPreviewProvider);
 
     const serverBin = Helper.getServerJarPath(location);
+    if (serverBin.error != null) {
+      vscode.window.showErrorMessage(serverBin.error);
+      return Promise.reject(serverBin.error);
+    }
     // use the following serverBin when you want to directly use the compiled server jar:
     // const prefix = __dirname.split("client")[0];
     // const serverBin = path.join(prefix, 'server', 'target', 'scala-2.12', 'server.jar')
 
-    const serverOptions: ServerOptions = () => State.startServerProcess(location, serverBin);
+    const serverOptions: ServerOptions = () => State.startServerProcess(location, serverBin.path);
     // use the following lines to connect to a server instance instead of starting a new one (e.g. for debugging purposes)
     /*
     const connectionInfo = {
@@ -183,13 +187,6 @@ export class State {
     }
     const serverOptions: ServerOptions = () => State.connectToServer(location, connectionInfo);
     */
-
-    // server binary was not found
-    if (!fs.existsSync(serverBin)) {
-      const msg = `The server binary ${serverBin} does not exist. Please update Gobra Tools.`;
-      vscode.window.showErrorMessage(msg);
-      return Promise.reject(msg);
-    }
 
     let clientOptions: LanguageClientOptions = {
       // register server for gobra files
@@ -289,7 +286,11 @@ export class State {
     await Helper.spawn(javaPath, ["-version"]);
     Helper.log("Checking Z3...");
     const z3Path = Helper.getZ3Path(location);
-    await Helper.spawn(z3Path, ["--version"]);
+    if (z3Path.error != null) {
+      vscode.window.showErrorMessage(z3Path.error);
+      return Promise.reject(z3Path.error);
+    }
+    await Helper.spawn(z3Path.path, ["--version"]);
     return javaPath;
   }
 

--- a/client/src/MessagePayloads.ts
+++ b/client/src/MessagePayloads.ts
@@ -25,12 +25,11 @@ export class VerifierConfig {
   z3Executable: string;
   boogieExecutable: string;
 
-  constructor(location: Location, files: FileData[]) {
+  constructor(files: FileData[], z3Executable: string, boogieExecutable: string) {
     this.fileData = files;
     this.gobraSettings = Helper.getGobraSettings();
-
-    this.z3Executable = Helper.getZ3Path(location);
-    this.boogieExecutable = Helper.getBoogiePath(location);
+    this.z3Executable = z3Executable;
+    this.boogieExecutable = boogieExecutable;
   }
 }
 

--- a/client/src/evaluate/EvaluationHelper.ts
+++ b/client/src/evaluate/EvaluationHelper.ts
@@ -54,7 +54,15 @@ export class EvaluationHelper {
   public static async verify(fileUri: URI, filePath: string): Promise<void> {
     const location = await Verifier.updateGobraTools(State.context, false);
     const fileData = new FileData(fileUri);
-    let config = new VerifierConfig(location, [fileData]);
+    const z3Path = Helper.getZ3Path(location);
+			const boogiePath = Helper.getBoogiePath(location);
+			if (z3Path.error != null) {
+				return Promise.reject(z3Path.error);
+			}
+			if (boogiePath.error != null) {
+				return Promise.reject(boogiePath.error);
+			}
+    let config = new VerifierConfig([fileData], z3Path.path, boogiePath.path);
 
     let settings = new EvaluationGobraSettings();
     config.gobraSettings = settings;

--- a/client/src/evaluate/EvaluationHelper.ts
+++ b/client/src/evaluate/EvaluationHelper.ts
@@ -55,13 +55,13 @@ export class EvaluationHelper {
     const location = await Verifier.updateGobraTools(State.context, false);
     const fileData = new FileData(fileUri);
     const z3Path = Helper.getZ3Path(location);
-			const boogiePath = Helper.getBoogiePath(location);
-			if (z3Path.error != null) {
-				return Promise.reject(z3Path.error);
-			}
-			if (boogiePath.error != null) {
-				return Promise.reject(boogiePath.error);
-			}
+    const boogiePath = Helper.getBoogiePath(location);
+    if (z3Path.error != null) {
+      return Promise.reject(z3Path.error);
+    }
+    if (boogiePath.error != null) {
+      return Promise.reject(boogiePath.error);
+    }
     let config = new VerifierConfig([fileData], z3Path.path, boogiePath.path);
 
     let settings = new EvaluationGobraSettings();

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -34,10 +34,20 @@ export function activate(context: vscode.ExtensionContext): Thenable<any> {
 		return location;
 	}
 
-	function initVerifier(fileUri: URI): (location: Location) => void {
-		return location => {
+	function initVerifier(fileUri: URI): (location: Location) => Promise<void> {
+		return async location => {
 			const fileData = new FileData(fileUri);
-			const verifierConfig = new VerifierConfig(location, [fileData]);
+			const z3Path = Helper.getZ3Path(location);
+			const boogiePath = Helper.getBoogiePath(location);
+			if (z3Path.error != null) {
+				vscode.window.showErrorMessage(z3Path.error);
+				return Promise.reject(z3Path.error);
+			}
+			if (boogiePath.error != null) {
+				vscode.window.showErrorMessage(boogiePath.error);
+				return Promise.reject(boogiePath.error);
+			}
+			const verifierConfig = new VerifierConfig([fileData], z3Path.path, boogiePath.path);
 			Verifier.initialize(context, verifierConfig, fileUri);
 			Notifier.notifyExtensionActivation();
 		}


### PR DESCRIPTION
This PR changes the behavior of the settings object `gobraDependencies.gobraToolsPaths` in the sense that changes only affect build version 'Local' and no longer 'Nightly' and 'Stable'.
Furthermore, the default paths have been updated to point to a sister folder next to `Stable` and `Nightly`, which is imho the most sensible location to place any modifications for build version 'Local'.
Additionally, changing the build version while Gobra is running now results in a popup indicating that VSCode needs to be restarted. After restart, the tools will then be installed. Previously, the tools would have been installed directly after changing the settings but a restart was still necessary.

Fixes #104