### PR TITLE
More Robust CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,15 +118,15 @@ jobs:
           name: server.jar
 
       - name: Download Viper Tools for Windows
-        run: curl --fail --silent --show-error https://viper.ethz.ch/downloads/ViperToolsWin.zip --output ViperToolsWin.zip
+        run: wget --no-verbose https://viper.ethz.ch/downloads/ViperToolsWin.zip --output-document=ViperToolsWin.zip
       - name: Unzip Viper Tools for Windows
         run: unzip ViperToolsWin.zip -d ViperToolsWin
       - name: Download Viper Tools for Linux
-        run: curl --fail --silent --show-error https://viper.ethz.ch/downloads/ViperToolsLinux.zip --output ViperToolsLinux.zip
+        run: wget --no-verbose https://viper.ethz.ch/downloads/ViperToolsLinux.zip --output-document=ViperToolsLinux.zip
       - name: Unzip Viper Tools for Linux
         run: unzip ViperToolsLinux.zip -d ViperToolsLinux
       - name: Download Viper Tools for macOS
-        run: curl --fail --silent --show-error https://viper.ethz.ch/downloads/ViperToolsMac.zip --output ViperToolsMac.zip
+        run: wget --no-verbose https://viper.ethz.ch/downloads/ViperToolsMac.zip --output-document=ViperToolsMac.zip
       - name: Unzip Viper Tools for macOS
         run: unzip ViperToolsMac.zip -d ViperToolsMac
 


### PR DESCRIPTION
Switches from curl to wget to make use of wget's built-in retry mechanism if download the Viper Tools fails in the CI