### PR TITLE
Disable plugins in ViperServer

### DIFF
--- a/server/src/main/scala/viper/gobraserver/GobraServerService.scala
+++ b/server/src/main/scala/viper/gobraserver/GobraServerService.scala
@@ -24,7 +24,7 @@ class GobraServerService(config: ServerConfig)(implicit executor: GobraServerExe
     // always send full text document for each notification:
     capabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental)
 
-    val options: List[String] = List("--logLevel", config.logLevel.levelStr)
+    val options: List[String] = List("--disablePlugins", "--logLevel", config.logLevel.levelStr)
     GobraServer.init(options)(executor)
     GobraServer.start()
 


### PR DESCRIPTION
Gobra already applies the necessary plugins (e.g. the termination plugin). Executing the plugins again within ViperServer as not only unnecessary but also not possible because the chopper (invoked before passing a Viper program to ViperServer) might have removed program parts that would be necessary by plugins. See [Gobra #625](https://github.com/viperproject/gobra/issues/625)