### PR TITLE
Only Auto-Verify on Save

### DIFF
--- a/client/src/ExtensionState.ts
+++ b/client/src/ExtensionState.ts
@@ -34,8 +34,6 @@ export class State {
   private static runningGoifications: Set<string>;
   private static runningGobrafications: Set<string>;
 
-  public static verificationRequestTimeout: NodeJS.Timeout | null;
-
   public static verifierConfig: VerifierConfig;
 
   public static isFileInvolvedInRunningVerification(fileUri: URI): Boolean {
@@ -129,26 +127,6 @@ export class State {
     State.verifierConfig.gobraSettings = Helper.getGobraSettings();
   }
 
-  public static setVerificationRequestTimeout(fileUri: URI, event: IdeEvents): void {
-    State.verificationRequestTimeout = setTimeout(() => {
-      Verifier.verify(fileUri, event);
-      State.clearVerificationRequestTimeout();
-    }, Helper.getTimeout());
-  }
-
-  public static clearVerificationRequestTimeout(): void {
-    if (State.verificationRequestTimeout != null) {
-      clearTimeout(State.verificationRequestTimeout);
-      State.verificationRequestTimeout = null;
-    }
-  }
-
-  public static refreshVerificationRequestTimeout(): void {
-    if (State.verificationRequestTimeout != null) {
-      State.verificationRequestTimeout.refresh();
-    }
-  }
-
 
   // creates the language client and starts the server
   public static startLanguageServer(context: vscode.ExtensionContext, fileSystemWatcher: vscode.FileSystemWatcher, location: Location): Promise<void> {
@@ -160,8 +138,6 @@ export class State {
 
     this.runningGoifications = new Set<string>();
     this.runningGobrafications = new Set<string>();
-
-    this.verificationRequestTimeout = null;
 
     this.viperPreviewProvider = new CodePreviewProvider();
     vscode.workspace.registerTextDocumentContentProvider(FileSchemes.viper, this.viperPreviewProvider);

--- a/client/src/VerificationService.ts
+++ b/client/src/VerificationService.ts
@@ -94,18 +94,6 @@ export class Verifier {
         });
         return;
       }
-
-      // don't set timeout when auto verification is off
-      if (!Helper.isAutoVerify()) return;
-
-      // don't set timeout when file was saved
-      if (change.contentChanges.length == 0) return;
-
-      if (State.verificationRequestTimeout) {
-        State.refreshVerificationRequestTimeout();
-      } else {
-        State.setVerificationRequestTimeout(change.document.uri, IdeEvents.FileChange);
-      }
     }));
 
     // change of build version
@@ -218,9 +206,6 @@ export class Verifier {
     */
   public static verifyFiles(fileUris: URI[], event: IdeEvents, isolationData: IsolationData[] = []): void {
     State.removeVerificationRequests(fileUris);
-
-
-    State.clearVerificationRequestTimeout();
 
     // return when no text editor is active
     if (!vscode.window.activeTextEditor) return;
@@ -378,7 +363,6 @@ export class Verifier {
     // State.updateFileData([fileUri]);
     const fileData = new FileData(fileUri);
     State.client.sendNotification(Commands.changeFile, Helper.fileDataToJson(fileData));
-    State.clearVerificationRequestTimeout();
   }
 
 


### PR DESCRIPTION
Triggering auto-verification based on some timeout since the last file modification results in many unnecessary verification attempts and sometimes triggers unstable Gobra behavior. Thus, this PR changes auto-verification to trigger verification only on open and on save of a file.