### PR TITLE
Enables plugins within ViperServer

### DIFF
--- a/client/src/test/data/decreases.gobra
+++ b/client/src/test/data/decreases.gobra
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 package decrease
 
 // this test case checks that Gobra / GobraServer correctly invokes

--- a/client/src/test/data/decreases.gobra
+++ b/client/src/test/data/decreases.gobra
@@ -1,0 +1,9 @@
+package decrease
+
+// this test case checks that Gobra / GobraServer correctly invokes
+// Viper plugins as verifying this file requires the termination plugin.
+
+decreases i
+func infiniteRecursion(i int) {
+    infiniteRecursion(i - 1)
+}

--- a/client/src/test/extension.test.ts
+++ b/client/src/test/extension.test.ts
@@ -21,6 +21,7 @@ const ASSERT_TRUE = "assert_true.gobra";
 const ASSERT_FALSE = "assert_false.gobra";
 const FAILING_POST_GOBRA = "failing_post.gobra";
 const FAILING_POST_GO = "failing_post.go";
+const DECREASES = "decreases.gobra";
 const PKG_FILE_1 = "pkg/file1.gobra";
 
 const URL_CONVERSION_TIMEOUT_MS = 5000; // 5s
@@ -227,6 +228,20 @@ suite("Extension", () => {
                 )
             ),
             "The 'false' expression in the postcondition of a go program was not reported."
+        );
+    });
+
+    test("Verify program requiring Viper plugins and underline non-terminating recursive call (Gobra Issue #823)", async function() {
+        this.timeout(GOBRA_VERIFICATION_TIMEOUT_MS);
+        const document = await openAndVerifyFile(DECREASES);
+        const diagnostics = vscode.languages.getDiagnostics(document.uri);
+        assert.ok(
+            diagnostics.some(
+                (diagnostic) => (
+                    document.getText(diagnostic.range).includes("infiniteRecursion(i - 1)")
+                )
+            ),
+            "The non-terminating recursive call was not reported."
         );
     });
 

--- a/server/src/main/scala/viper/gobraserver/GobraServerService.scala
+++ b/server/src/main/scala/viper/gobraserver/GobraServerService.scala
@@ -24,7 +24,7 @@ class GobraServerService(config: ServerConfig)(implicit executor: GobraServerExe
     // always send full text document for each notification:
     capabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental)
 
-    val options: List[String] = List("--disablePlugins", "--logLevel", config.logLevel.levelStr)
+    val options: List[String] = List("--logLevel", config.logLevel.levelStr)
     GobraServer.init(options)(executor)
     GobraServer.start()
 


### PR DESCRIPTION
As mentioned in [Gobra Issue #823](https://github.com/viperproject/gobra/issues/823), [Gobra PR #818](https://github.com/viperproject/gobra/pull/818) changes the way Gobra executes Viper plugins. In particular, Gobra no longer executes them but we rely on the Viper backend to execute the plugins before attempting to verify a program.
Due to this change, Gobra-IDE so far does not support the changeset introduced by [Gobra PR #818](https://github.com/viperproject/gobra/pull/818), which results in the backend consistently crashing whenever a verification is performed.
This PR addresses this issue by instructing ViperServer to execute the Viper plugins.