### PR TITLE
Registers the command to update the Gobra tools during activation

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gobra-ide",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gobra-ide",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gobra-ide",
   "displayName": "Gobra IDE",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "publisher": "viper-admin",
   "description": "This extension provides interactive IDE features for verifying programs in Gobra.",
   "author": {

--- a/client/src/VerificationService.ts
+++ b/client/src/VerificationService.ts
@@ -43,7 +43,6 @@ export class Verifier {
     Helper.registerCommand(ContributionCommands.verifyFile, Verifier.manualVerifyFile, context);
     Helper.registerCommand(ContributionCommands.verifyPackage, Verifier.manualVerifyPackage, context);
     Helper.registerCommand(ContributionCommands.verifyMember, Verifier.manualVerifyMember, context);
-    Helper.registerCommand(ContributionCommands.updateGobraTools, () => Verifier.updateGobraTools(context, true), context);
     Helper.registerCommand(ContributionCommands.showViperCodePreview, Verifier.showViperCodePreview, context);
     Helper.registerCommand(ContributionCommands.showInternalCodePreview, Verifier.showInternalCodePreview, context);
     Helper.registerCommand(ContributionCommands.showJavaPath, () => Verifier.showJavaPath(), context);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import { State } from './ExtensionState';
 import { Verifier } from './VerificationService';
 import { FileData, VerifierConfig } from './MessagePayloads';
-import { Helper } from './Helper';
+import { ContributionCommands, Helper } from './Helper';
 import * as Notifier from './Notifier';
 import { Location } from 'vs-verification-toolbox';
 
@@ -67,6 +67,12 @@ export function activate(context: vscode.ExtensionContext): Thenable<any> {
 			Helper.log(`cleanInstall has been requested but gobra tools do not exist yet --> NOP`);
 		}
 	}
+
+	// register the command to update the Gobra tools before starting the server such that the
+	// command is available even if starting the server fails, e.g., because the installed Gobra
+	// tools are incompatible with this extension. Otherwise, users would have no way to recover
+	// by updating the Gobra tools from within the IDE:
+	Helper.registerCommand(ContributionCommands.updateGobraTools, () => Verifier.updateGobraTools(context, true), context);
 
 	// install gobra tools
 	return Verifier.updateGobraTools(context, false)


### PR DESCRIPTION
The command 'Gobra: Update Gobra Tools' was previously registered in `Verifier.initialize`, i.e., only after the Gobra server was started successfully. However, if starting the server fails — e.g., because the installed Gobra tools are incompatible with this extension version (they were updated to a version implementing a newer communication protocol) — the command was never registered. Users were thus left without a way to recover by updating the Gobra tools from within the IDE.

The command is now registered at the beginning of the extension's activation, before the Gobra tools are located and the server is started. Note that `State.disposeServer` (invoked when confirming an update) already handles a not-yet-started server, and commands registered before a failed activation remain invocable.

This is a preparation for the upcoming breaking server change on `next-gen` (viperproject/gobra-ide#641): it should be released to users before the new Gobra tools appear in a published GitHub release, such that as many users as possible have a recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)