### PR TITLE
Handles stopping a never-initialized server

### DIFF
--- a/server/src/main/scala/viper/gobraserver/GobraServer.scala
+++ b/server/src/main/scala/viper/gobraserver/GobraServer.scala
@@ -254,6 +254,13 @@ object GobraServer extends GobraFrontend {
 
 
   def stop(): Future[Unit] = {
+    // the server might have never been initialized, e.g., because it rejected the initialize
+    // request of an incompatible client. In this case, there is nothing to stop. Note that this
+    // case is not just hypothetical: incompatible clients stop the server, e.g., when updating
+    // the Gobra tools, and responding with an error would abort such an update:
+    if (_server == null) {
+      return Future.successful(())
+    }
     _server.stop().map(_ => ())(_executor)
   }
 


### PR DESCRIPTION
Newer Gobra servers (viperproject/gobra-ide#641) reject the initialize request of incompatible clients, in which case the server's internals never get initialized. Stopping the server in this state — which incompatible clients do, e.g., when updating the Gobra tools — resulted in a `NullPointerException` (`GobraServer.stop` on a null `_server`) that lsp4j reported to the client as a generic `-32603 Internal error.`, aborting the tools update with "Downloading and unzipping the Gobra Tools has failed (reason: 'Error: Internal error.')". Such clients thus had no way to recover by updating the Gobra tools.

`GobraServer.stop` now completes successfully when there is nothing to stop.

Verified against the assembled server: an initialize request without a protocol version is rejected as before, and a subsequent shutdown request now completes with `"result": null` instead of the internal error; the extension test suite passes against the fixed server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)