### PR TITLE
Updates the Gobra tools even if stopping the server fails

### DIFF
--- a/client/src/VerificationService.ts
+++ b/client/src/VerificationService.ts
@@ -418,7 +418,14 @@ export class Verifier {
     /** confirms the update and shuts down Gobra Server if it is running */
     async function confirmAndStopServer(): Promise<ConfirmResult> {
       const confirmResult = await confirm();
-      await State.disposeServer();
+      // stopping the server may fail, e.g., when the installed Gobra tools are incompatible with
+      // this extension version. Especially in such situations, updating the Gobra tools has to
+      // remain possible. Thus, failures are logged but otherwise ignored:
+      try {
+        await State.disposeServer();
+      } catch (e) {
+        Helper.log(`stopping the Gobra server has failed -- the Gobra tools will be updated nonetheless (${e})`);
+      }
       return confirmResult;
     }
     


### PR DESCRIPTION
Before updating the Gobra tools, the running Gobra server is stopped (`confirmAndStopServer` in `Verifier.updateGobraTools`). Stopping the server may fail, e.g., when the installed Gobra tools are incompatible with this extension version and the server rejected the initialize request (the shutdown request then failed with `-32603 Internal error.`, see #643, aborting the whole update with "Downloading and unzipping the Gobra Tools has failed (reason: 'Error: Internal error.')").

Since updating the Gobra tools is the way to recover from exactly such situations, failures while stopping the server are now logged but no longer abort the update. Together with #642 (command registration during activation) and #643 (server-side fix), this makes the recovery path robust: the update command exists even when activation fails, and completes even against a server that cannot be stopped cleanly — including the already-distributed server builds that predate #643.

Partially addresses #35 such that at least the Gobra Tools can be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)