### PR TITLE
Tests the build version 'External' and removes multi-configuration leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,17 +136,20 @@ Run `npx github:viperproject/check-license-header#v1 check --config .github/lice
 
 ## Release Management
 A nightly release is created daily at 7:00 UTC.
-Stable releases should be created as follows (manually triggered nightly releases can be created similarly as well):
+Stable releases and pre-releases should be created as follows (manually triggered nightly releases can be created similarly as well):
 1. Open [test workflow on GitHub.com](https://github.com/viperproject/gobra-ide/actions?query=workflow%3Atest)
 2. Click on "Run workflow"
-3. Choose `master` branch, type `stable` (`nightly` for manually creating a nightly release), a tag name (e.g. `v1.0-beta.1`), and a release name (this will become the release's title).
+3. Choose the branch, type `stable` or `pre-release` (`nightly` for manually creating a nightly release), a tag name (e.g. `v1.0-beta.1`), and a release name (this will become the release's title).
 
 Type `stable` will create a draft release with the chosen tag name (the tag itself will be created when publishing the release) and release name.
-The release body will consist of the commit hashes of the depending repositories.
-In addition, the release assets will be created and attached to the release.
-Please wait until the workflow has completed before publishing the release because Gobra IDE will use the assets of the latest published release.
+The release body will consist of the commit hashes and versions of the dependencies.
+In addition, the release assets (the platform-specific extensions and Gobra tools) will be created and attached to the release.
+Once the workflow has completed, the extension is published to the Visual Studio Marketplace and the Open VSX Registry if the version in `client/package.json` differs from the latest published one.
 
-In case the type `nightly` was selected, the same steps will be performed as done for the periodic nightly releases.
+Type `pre-release` behaves like `stable` but publishes the extension to the marketplaces as a pre-release version, which users have to opt into ("Switch to Pre-Release Version").
+Note that the marketplaces do not support semver pre-release suffixes and always serve users the highest version number of the respective channel: stable releases should use an even minor version (e.g. `3.0.x`, `3.2.x`) and pre-releases an odd one (e.g. `3.1.x`, `3.3.x`).
+
+In case the type `nightly` was selected, a GitHub pre-release is created (no marketplace publishing).
 Note that in this case the tag name and release name will be ignored.
 
 Alternatively, the manual triggering of the workflow can be done via command line:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ A nightly release is created daily at 7:00 UTC.
 Stable releases and pre-releases should be created as follows (manually triggered nightly releases can be created similarly as well):
 1. Open [test workflow on GitHub.com](https://github.com/viperproject/gobra-ide/actions?query=workflow%3Atest)
 2. Click on "Run workflow"
-3. Choose the branch, type `stable` or `pre-release` (`nightly` for manually creating a nightly release), a tag name (e.g. `v1.0-beta.1`), and a release name (this will become the release's title).
+3. Choose the branch, type `stable` or `pre-release` (`nightly` for manually creating a nightly release), a tag name (e.g. `v1.0-beta.1`), and a release name (this will become the release's title). Mind the version convention below when choosing the type.
 
 Type `stable` will create a draft release with the chosen tag name (the tag itself will be created when publishing the release) and release name.
 The release body will consist of the commit hashes and versions of the dependencies.
@@ -147,7 +147,8 @@ In addition, the release assets (the platform-specific extensions and Gobra tool
 Once the workflow has completed, the extension is published to the Visual Studio Marketplace and the Open VSX Registry if the version in `client/package.json` differs from the latest published one.
 
 Type `pre-release` behaves like `stable` but publishes the extension to the marketplaces as a pre-release version, which users have to opt into ("Switch to Pre-Release Version").
-Note that the marketplaces do not support semver pre-release suffixes and always serve users the highest version number of the respective channel: stable releases should use an even minor version (e.g. `3.0.x`, `3.2.x`) and pre-releases an odd one (e.g. `3.1.x`, `3.3.x`).
+**Version convention: pre-releases must use an odd minor version (e.g. `3.1.x`, `3.3.x`) and stable releases an even one (e.g. `3.0.x`, `3.2.x`).**
+This is necessary because the marketplaces do not support semver pre-release suffixes and always serve users the highest version number of the respective channel.
 
 In case the type `nightly` was selected, a GitHub pre-release is created (no marketplace publishing).
 Note that in this case the tag name and release name will be ignored.

--- a/client/src/MessagePayloads.ts
+++ b/client/src/MessagePayloads.ts
@@ -91,15 +91,9 @@ export interface PathSettings {
   serverJar: PlatformDependendPath;
 }
 
-export interface ProviderSettings {
-  stable: PlatformDependendPath;
-  nightly: PlatformDependendPath;
-}
-
 export interface GobraDependencies {
   java: JavaSettings;
   gobraToolsPaths: PathSettings;
-  gobraToolsProvider: ProviderSettings;
 }
 
 export interface PlatformDependendPath {

--- a/client/src/MessagePayloads.ts
+++ b/client/src/MessagePayloads.ts
@@ -78,6 +78,9 @@ export interface GobraSettings {
   includeDirs: string[];
 }
 
+// note that the following settings-related types (up to and including `PlatformDependendPath`)
+// are NOT message payloads: they only type the client-side `vscode.workspace.getConfiguration`
+// accesses and have no counterpart in the server's MessagePayloads.scala:
 export interface JavaSettings {
   javaBinary: string;
   cwd: string;

--- a/client/src/test/data/settings/external.json
+++ b/client/src/test/data/settings/external.json
@@ -1,0 +1,6 @@
+{
+    "gobraSettings.buildVersion": "External",
+    "gobraDependencies.gobraToolsPaths.gobraToolsBasePath.windows": "$builtinGobraTools$",
+    "gobraDependencies.gobraToolsPaths.gobraToolsBasePath.linux": "$builtinGobraTools$",
+    "gobraDependencies.gobraToolsPaths.gobraToolsBasePath.mac": "$builtinGobraTools$"
+}

--- a/client/src/test/extension.test.ts
+++ b/client/src/test/extension.test.ts
@@ -32,7 +32,7 @@ const FAILING_POST_GO = "failing_post.go";
 const DECREASES = "decreases.gobra";
 const PKG_FILE_1 = "pkg/file1.gobra";
 
-const GOBRA_TOOL_UPDATE_TIMEOUT_MS = 4 * 60 * 1000; // 4min
+const EXTENSION_STARTUP_TIMEOUT_MS = 4 * 60 * 1000; // 4min
 const GOBRA_VERIFICATION_TIMEOUT_MS = 1 * 60 * 1000; // 1min
 
 function log(msg: string) {
@@ -138,8 +138,8 @@ async function openAndVerifyPackage(fileName: string, multipleFilesInPackageExpe
 suite("Extension", () => {
 
     suiteSetup(async function() {
-        // set timeout to a large value such that extension can be started and Gobra tools installed:
-        this.timeout(GOBRA_TOOL_UPDATE_TIMEOUT_MS);
+        // set timeout to a large value such that the extension (including the Gobra server) can be started:
+        this.timeout(EXTENSION_STARTUP_TIMEOUT_MS);
         // Dynamically import from the webpack bundle (async, doesn't block the event loop)
         const ext = await import('../extension.js');
         State = ext.State;

--- a/client/src/test/runTest.ts
+++ b/client/src/test/runTest.ts
@@ -83,6 +83,12 @@ async function main() {
 			const workspace_settings_path = path.join(workspace_vscode_path, "settings.json");
 			fs.mkdirSync(workspace_vscode_path);
 			fs.copyFileSync(settings_path, workspace_settings_path);
+			// substitute the placeholder for the bundled Gobra tools (assembled by
+			// `download-dependencies.ts` as part of `pre-test`). This allows testing that the
+			// bundled Gobra tools also work when configured as build version 'External':
+			const builtinGobraToolsPath = path.join(PROJECT_ROOT, "dependencies", "GobraTools");
+			const settingsContent = fs.readFileSync(workspace_settings_path).toString();
+			fs.writeFileSync(workspace_settings_path, settingsContent.replaceAll("$builtinGobraTools$", builtinGobraToolsPath.replaceAll("\\", "\\\\")));
 
 			// get environment variables
 			const env: NodeJS.ProcessEnv = process.env;


### PR DESCRIPTION
Since the Gobra tools are bundled with the extension (#641), testing against downloaded tool configurations (`Stable`/`Nightly`) is obsolete. #641 already removed the build channels, the provider setting, the update command, and the test overrides; this PR removes the remaining leftovers and adds the one configuration still worth testing:

- Removes the unused `ProviderSettings` payload type and the `gobraToolsProvider` field (the corresponding setting was removed in #641).
- Renames `GOBRA_TOOL_UPDATE_TIMEOUT_MS` to `EXTENSION_STARTUP_TIMEOUT_MS` (the tool-update test no longer exists; the constant only bounds the suite setup).
- Updates the release-management documentation for the `stable` / `pre-release` / `nightly` workflow types, including the marketplace pre-release channel and the even/odd minor-version convention.
- **New test configuration `external.json`**: runs the entire suite with `gobraSettings.buildVersion: External` and `gobraToolsBasePath` pointing at the very same bundled Gobra tools (the test runner substitutes a `$builtinGobraTools$` placeholder with `client/dependencies/GobraTools`). This proves that externally configured Gobra tools keep working. The CI config matrix picks the new configuration up automatically — note that this roughly doubles the client-test wall time per target.

Verified locally (darwin-arm64): both configurations pass the full suite (9 passing each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)